### PR TITLE
Make imperial units option use feet and decimal inches

### DIFF
--- a/Shared/HeightBar.cs
+++ b/Shared/HeightBar.cs
@@ -191,7 +191,7 @@ namespace HeightBar
 #endif
 
             var value = _useFeet.Value
-                ? (_barObject.transform.localPosition.y * Ratio * 0.0328084f).ToString("F2") + " feet"
+                ? Math.Floor(_barObject.transform.localPosition.y * Ratio * 0.0328084f).ToString("F2") + " ft " + (_barObject.transform.localPosition.y * Ratio * 0.3937007f % 12).ToString("F3") + " in"
                 : (_barObject.transform.localPosition.y * Ratio).ToString("F1") + "cm";
 
             ShadowAndOutline.DrawOutline(_labelRect, value, _labelStyle, Color.white, Color.black, 1);


### PR DESCRIPTION
Self-explanatory. Currently the option uses decimal feet, which is rarely used (because that'd make too much sense), this changes it so that it appears as feet and then decimal inches.
e.g. 160 cm now appears as 5 ft 2.992 in, rather than 5.249 ft
(i did this with practically 0 programming experience so please be gentle)